### PR TITLE
Added the raster variables into the analysis scripts for HCANA & ENGINE comparisions

### DIFF
--- a/Macros/analyze_engine_tree.h
+++ b/Macros/analyze_engine_tree.h
@@ -48,7 +48,12 @@ public :
    Float_t         sdc_yptg[20];   //[sdc_ntr]
    Float_t         sdc_delta[20];   //[sdc_ntr]
    Float_t         sdc_ptar[20];   //[sdc_ntr]
-
+   Float_t         frx_raw_adc[20];  
+   Float_t         fry_raw_adc[20];  
+   Float_t         frx_adc[20];  
+   Float_t         fry_adc[20];  
+   Float_t         frx[20];  
+   Float_t         fry[20];  
    // List of branches
    TBranch        *b_evnum;   //!
    TBranch        *b_evtype;   //!
@@ -76,6 +81,12 @@ public :
    TBranch        *b_sdc_yptg;   //!
    TBranch        *b_sdc_delta;   //!
    TBranch        *b_sdc_ptar;   //!
+   TBranch        *b_frx_raw_adc;   //!
+   TBranch        *b_fry_raw_adc;   //!
+   TBranch        *b_frx_adc;   //!
+   TBranch        *b_fry_adc;   //!
+   TBranch        *b_frx;   //!
+   TBranch        *b_fry;   //!
 
    analyze_engine_tree(TString ifile,TTree *tree=0);
    virtual ~analyze_engine_tree();
@@ -174,6 +185,12 @@ void analyze_engine_tree::Init(TTree *tree)
    fChain->SetBranchAddress("sdc_yptg", sdc_yptg, &b_sdc_yptg);
    fChain->SetBranchAddress("sdc_delta", sdc_delta, &b_sdc_delta);
    fChain->SetBranchAddress("sdc_ptar", sdc_ptar, &b_sdc_ptar);
+   fChain->SetBranchAddress("frx_raw_adc", frx_raw_adc, &b_frx_raw_adc);
+   fChain->SetBranchAddress("fry_raw_adc", fry_raw_adc, &b_fry_raw_adc);
+   fChain->SetBranchAddress("frx_adc", frx_adc, &b_frx_adc);
+   fChain->SetBranchAddress("fry_adc", fry_adc, &b_fry_adc);
+   fChain->SetBranchAddress("frx", frx, &b_frx);
+   fChain->SetBranchAddress("fry", fry, &b_fry);
    Notify();
 }
 
@@ -208,7 +225,7 @@ void analyze_engine_tree::PrintTrack(Long64_t entry)
 // If entry is not specified, print current entry
    if (!fChain) return;
    fChain->GetEntry(entry);
-   cout << " Engine event number = " << evnum << " event type = " << evtype << endl;
+   cout << "\nEngine event number = " << evnum << " event type = " << evtype << endl;
    if (evtype == 1||evtype == 3) {
    cout << "HMS  Number of Tracks  = " << hdc_ntr << endl;
    printf(" Track focal plane  x (cm)    y (cm)    dx/dz     dy/dz  \n");
@@ -235,5 +252,12 @@ void analyze_engine_tree::PrintTrack(Long64_t entry)
    }
    cout << " Print track target info sorted by chi-squared " << endl;
    }
+   cout<<" Raster x_raw_adc = "<<frx_raw_adc[i]
+       <<"\n        y_raw_adc = "<<fry_raw_adc[i]
+       <<"\n        x_adc = "<<frx_adc[i]
+       <<"\n        y_adc = "<<fry_adc[i]
+       <<"\n        x = "<<frx[i]
+       <<"\n        x = "<<fry[i] <<endl;
+
 }
 #endif // #ifdef analyze_engine_tree_cxx

--- a/Macros/analyze_hcana_tree.h
+++ b/Macros/analyze_hcana_tree.h
@@ -700,6 +700,12 @@ public :
    Double_t        S_hod_hgoodstarttime;
    Double_t        S_hod_starttime;
    Double_t        S_tr_n;
+   Double_t        RB_raster_frx_raw_adc;
+   Double_t        RB_raster_fry_raw_adc;
+   Double_t        RB_raster_frx_adc;
+   Double_t        RB_raster_fry_adc;
+   Double_t        RB_raster_frx;
+   Double_t        RB_raster_fry;
    Double_t        g_evnum;
  //THaEvent        *Event_Branch;
    ULong64_t       fEvtHdr_fEvtTime;
@@ -1397,6 +1403,12 @@ public :
    TBranch        *b_Event_Branch_fEvtHdr_fHelicity;   //!
    TBranch        *b_Event_Branch_fEvtHdr_fTargetPol;   //!
    TBranch        *b_Event_Branch_fEvtHdr_fRun;   //!
+   TBranch        *b_RB_raster_frx_raw_adc;
+   TBranch        *b_RB_raster_fry_raw_adc;
+   TBranch        *b_RB_raster_frx_adc;
+   TBranch        *b_RB_raster_fry_adc;
+   TBranch        *b_RB_raster_frx;
+   TBranch        *b_RB_raster_fry;
 
    analyze_hcana_tree(TString ifile,TTree *tree=0);
    virtual ~analyze_hcana_tree();
@@ -2155,6 +2167,14 @@ void analyze_hcana_tree::Init(TTree *tree)
    fChain->SetBranchAddress("fEvtHdr.fHelicity", &fEvtHdr_fHelicity, &b_Event_Branch_fEvtHdr_fHelicity);
    fChain->SetBranchAddress("fEvtHdr.fTargetPol", &fEvtHdr_fTargetPol, &b_Event_Branch_fEvtHdr_fTargetPol);
    fChain->SetBranchAddress("fEvtHdr.fRun", &fEvtHdr_fRun, &b_Event_Branch_fEvtHdr_fRun);
+   fChain->SetBranchAddress("RB.raster.frx_raw_adc", &RB_raster_frx_raw_adc, &b_RB_raster_frx_raw_adc);
+   fChain->SetBranchAddress("RB.raster.fry_raw_adc", &RB_raster_fry_raw_adc, &b_RB_raster_fry_raw_adc);
+   fChain->SetBranchAddress("RB.raster.frx_adc", &RB_raster_frx_adc, &b_RB_raster_frx_adc);
+   fChain->SetBranchAddress("RB.raster.fry_adc", &RB_raster_fry_adc, &b_RB_raster_fry_adc);
+   fChain->SetBranchAddress("RB.raster.frx", &RB_raster_frx, &b_RB_raster_frx);
+   fChain->SetBranchAddress("RB.raster.fry", &RB_raster_fry, &b_RB_raster_fry);
+
+
    Notify();
 }
 

--- a/output_replay_both.def
+++ b/output_replay_both.def
@@ -94,7 +94,10 @@ TH1F dtime_hdc2y2 'HDC 2Y2 Drift Time' H.dc.2y2.time 200 -100 300
 TH1F dtime_hdc2x2 'HDC 2X2 Drift Time' H.dc.2x2.time 200 -100 300
 
 # Beam related ADC channels. eg. raster
-TH1F rstrx_i 'Raster X Current' RB.raster.xcurrent 4000 -2000 2000
-TH1F rstry_i 'Raster Y Current' RB.raster.ycurrent 4000 -2000 2000
-TH1F rstrx_p 'Raster X Position' RB.raster.xpos 40 -20   20
-TH1F rstry_p 'Raster Y Position' RB.raster.ypos 40 -20   20
+TH1F frx_raw_adc 'Raster X Raw ADC' RB.raster.frx_raw_adc 1200 3200 4400
+TH1F fry_raw_adc 'Raster Y Raw ADC' RB.raster.fry_raw_adc 1200 3200 4400
+TH1F frx_adc 'Raster X ADC' RB.raster.frx_adc 1000 -500 500
+TH1F fry_adc 'Raster Y ADC' RB.raster.fry_adc 1000 -500 500
+TH1F frx 'Raster X Position' RB.raster.frx 100 -0.5   0.5
+TH1F fry 'Raster Y Position' RB.raster.fry 100 -0.5   0.5
+


### PR DESCRIPTION
The scripts analyze_engine_tree.h and analyze_hcana_tree.h were modified to load the raster variables from both ENGINE and HCANA roofiles. output_replay_both.def was modified with the new raster histo definitions. All of these files are needed to run replay_both.C script.
