### PR TITLE
Some more changes for raster comparision

### DIFF
--- a/Macros/analyze_engine_tree.h
+++ b/Macros/analyze_engine_tree.h
@@ -48,12 +48,12 @@ public :
    Float_t         sdc_yptg[20];   //[sdc_ntr]
    Float_t         sdc_delta[20];   //[sdc_ntr]
    Float_t         sdc_ptar[20];   //[sdc_ntr]
-   Float_t         frx_raw_adc[20];  
-   Float_t         fry_raw_adc[20];  
-   Float_t         frx_adc[20];  
-   Float_t         fry_adc[20];  
-   Float_t         frx[20];  
-   Float_t         fry[20];  
+   Float_t         frx_raw_adc;  
+   Float_t         fry_raw_adc;  
+   Float_t         frx_adc;  
+   Float_t         fry_adc;  
+   Float_t         frx;  
+   Float_t         fry;  
    // List of branches
    TBranch        *b_evnum;   //!
    TBranch        *b_evtype;   //!
@@ -185,12 +185,12 @@ void analyze_engine_tree::Init(TTree *tree)
    fChain->SetBranchAddress("sdc_yptg", sdc_yptg, &b_sdc_yptg);
    fChain->SetBranchAddress("sdc_delta", sdc_delta, &b_sdc_delta);
    fChain->SetBranchAddress("sdc_ptar", sdc_ptar, &b_sdc_ptar);
-   fChain->SetBranchAddress("frx_raw_adc", frx_raw_adc, &b_frx_raw_adc);
-   fChain->SetBranchAddress("fry_raw_adc", fry_raw_adc, &b_fry_raw_adc);
-   fChain->SetBranchAddress("frx_adc", frx_adc, &b_frx_adc);
-   fChain->SetBranchAddress("fry_adc", fry_adc, &b_fry_adc);
-   fChain->SetBranchAddress("frx", frx, &b_frx);
-   fChain->SetBranchAddress("fry", fry, &b_fry);
+   fChain->SetBranchAddress("frx_raw_adc", &frx_raw_adc, &b_frx_raw_adc);
+   fChain->SetBranchAddress("fry_raw_adc", &fry_raw_adc, &b_fry_raw_adc);
+   fChain->SetBranchAddress("frx_adc", &frx_adc, &b_frx_adc);
+   fChain->SetBranchAddress("fry_adc", &fry_adc, &b_fry_adc);
+   fChain->SetBranchAddress("frx", &frx, &b_frx);
+   fChain->SetBranchAddress("fry", &fry, &b_fry);
    Notify();
 }
 

--- a/Macros/comp_beam_engine_hcana.C
+++ b/Macros/comp_beam_engine_hcana.C
@@ -1,0 +1,171 @@
+/*
+Date - 05-05-2014
+Author - B.Waidyawansa
+
+Coppied from comp_hms_engine_hcana.C to generate beam comparision plots. Start with raster.
+
+ */
+
+#include "analyze_hcana_tree.h"
+#include "analyze_engine_tree.h"
+#include <TCanvas.h>
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <TStyle.h>
+
+void comp_beam_engine_hcana( TString hcana_file, TString engine_file) {
+  analyze_hcana_tree *myhcana = new analyze_hcana_tree(hcana_file,0);
+  analyze_engine_tree *myengine = new analyze_engine_tree(engine_file,0);
+  Long64_t nent_hcana = myhcana->fChain->GetEntriesFast();
+  Long64_t nent_engine = myengine->fChain->GetEntriesFast();
+  Long64_t nent_loop=TMath::Min(nent_hcana,nent_engine);
+  cout << " hcana entries = " << nent_hcana << " engine entries = " << nent_engine  << endl;
+  Long64_t nb_hcana = 0,nb_engine = 0;
+
+  TH1F *rb_frx_raw_adc[2],*rb_fry_raw_adc[2],*rb_frx_adc[2],*rb_fry_adc[2],*rb_frx[2],*rb_fry[2];
+  TH1F *pos_diff[2],*raw_adc_diff[2], *adc_diff[2]; 
+
+  TString comp[2] = {"eng","hcana"};
+  Int_t i;
+
+  for (i=0 ; i<2 ;i++) {
+    rb_frx_raw_adc[i] =  new TH1F(Form("rb_frx_raw_adc_%s",comp[i].Data()),"frx_raw_adc; Raw ADC value; Events",1200,3200,4400);
+    rb_fry_raw_adc[i] =  new TH1F(Form("rb_fry_raw_adc_%s",comp[i].Data()),"fry_raw_adc; Raw ADC value; Events",1200,3200,4400);
+    rb_frx_adc[i] =  new TH1F(Form("rb_frx_adc_%s",comp[i].Data()),"frx_adc; ADC value; Events",1000,-500,500);
+    rb_fry_adc[i] =  new TH1F(Form("rb_fry_adc_%s",comp[i].Data()),"fry_adc; ADC value; Events",1000,-500,500);
+    rb_frx[i] =  new TH1F(Form("rb_frx_%s",comp[i].Data()),"frx; Position (cm); Events",100,-0.5,0.5);
+    rb_fry[i] =  new TH1F(Form("rb_fry_%s",comp[i].Data()),"fry; Position (cm); Events",100,-0.5,0.5);
+
+    pos_diff[i] =  new TH1F(Form("pos_diff_%d",i),"Differences in reconstructed position; Difference (cm); Events",100,-0.5,0.5);
+    raw_adc_diff[i] =  new TH1F(Form("raw_adc_dif_%d",i),"Differences in raw ADC values; Difference ; Events",1200,3200,4400);
+    adc_diff[i] =  new TH1F(Form("adc_diff_%d",i),"Differences in pedestal corrected ADC values; Difference; Events",1000,-500,500);
+  }
+
+  //
+  char *s = new char[1];
+  Long64_t engine_ent=0;
+  for (Long64_t ni=0 ; ni<nent_loop ;ni++) {
+      nb_hcana = myhcana->fChain->GetEntry(ni);
+      nb_engine = myengine->fChain->GetEntry(engine_ent++);
+      while (myhcana->g_evnum!=myengine->evnum) {
+	nb_engine = myengine->fChain->GetEntry(engine_ent++);
+      }
+      if (myhcana->fEvtHdr_fEvtType==1&& myengine->evtype==1 && myhcana->g_evnum==myengine->evnum) {
+	rb_frx_raw_adc[1]->Fill(myhcana->RB_raster_frx_raw_adc);
+	rb_frx_raw_adc[0]->Fill(myengine->fry_raw_adc);
+	
+	rb_frx_adc[1]->Fill(myhcana->RB_raster_frx_adc);
+	rb_frx_adc[0]->Fill(myengine->frx_adc);
+
+	rb_frx[1]->Fill(myhcana->RB_raster_frx);
+	rb_frx[0]->Fill(myengine->frx);
+
+	rb_fry_raw_adc[1]->Fill(myhcana->RB_raster_fry_raw_adc);
+	rb_fry_raw_adc[0]->Fill(myengine->frx_raw_adc);
+
+	rb_fry_adc[1]->Fill(myhcana->RB_raster_fry_adc);
+	rb_fry_adc[0]->Fill(myengine->fry_adc);
+
+	rb_fry[1]->Fill(myhcana->RB_raster_fry);
+	rb_fry[0]->Fill(myengine->fry);
+      } // if
+
+  } // for loop
+
+  cout << " Hcana File= " << hcana_file << endl;
+  cout << " Engine File= " << engine_file << endl;
+  gStyle->Reset();
+
+  TStyle *MyStyle = new TStyle("MyStyle"," My Style");
+  //  MyStyle->SetOptStat(10000010);
+  MyStyle->SetOptStat("i");
+
+  MyStyle->SetTitleOffset(1.5,"Y");
+  MyStyle->SetTitleOffset(.7,"X");
+  MyStyle->SetLabelSize(0.04,"XY");
+  MyStyle->SetTitleSize(0.06,"XY");
+  MyStyle->SetTitleH(0.04);
+  MyStyle->SetPadLeftMargin(0.12);
+  MyStyle->SetStatFontSize(0.2);
+  MyStyle->SetTitleFontSize(0.1);
+  gROOT->SetStyle("MyStyle");
+
+  //draw X signals
+  TCanvas * cx = new TCanvas("cx","Compare Raster X Signals",1000,1200);
+  cx->Divide(2,3);
+
+  cx->cd(1);
+  rb_frx_raw_adc[0]->Draw();
+  rb_frx_raw_adc[1]->Draw("same");
+  rb_frx_raw_adc[0]->SetLineColor(2);
+  legx = new TLegend(0.15,0.8,0.30,0.88);
+  legx->AddEntry(rb_frx_raw_adc[0],"ENGINE","l");
+  legx->AddEntry(rb_frx_raw_adc[1],"HCANA","l");
+  legx->Draw();
+
+  cx->cd(2);
+  raw_adc_diff[0]->Add(rb_frx_raw_adc[1],rb_frx_raw_adc[0],-1);
+  raw_adc_diff[0]->Draw();
+  raw_adc_diff[0]->SetLineColor(kGreen-2);
+
+  cx->cd(3);
+  rb_frx_adc[0]->Draw();
+  rb_frx_adc[1]->Draw("same");
+  rb_frx_adc[0]->SetLineColor(2);
+
+  cx->cd(4);
+  adc_diff[0]->Add(rb_frx_adc[1],rb_frx_adc[0],-1);
+  adc_diff[0]->Draw();
+  adc_diff[0]->SetLineColor(kGreen-2);
+
+  cx->cd(5);
+  rb_frx[0]->Draw();
+  rb_frx[1]->Draw("same");
+  rb_frx[0]->SetLineColor(2);
+
+  cx->cd(6);
+  pos_diff[0]->Add(rb_frx[1],rb_frx[0],-1);
+  pos_diff[0]->Draw();
+  pos_diff[0]->SetLineColor(kGreen-2);
+
+  // draw Y signals
+  TCanvas * cy = new TCanvas("cy","Compare Raster Y Signals",1000,1200);
+  cy->Divide(2,3);
+
+  cy->cd(1);
+  rb_fry_raw_adc[0]->Draw();
+  rb_fry_raw_adc[1]->Draw("same");
+  rb_fry_raw_adc[0]->SetLineColor(2);
+  legy = new TLegend(0.15,0.8,0.3,0.88);
+  legy->AddEntry(rb_fry_raw_adc[0],"ENGINE","l");
+  legy->AddEntry(rb_fry_raw_adc[1],"HCANA","l");
+  legy->Draw();
+
+  cy->cd(2);
+  raw_adc_diff[1]->Add(rb_fry_raw_adc[1],rb_fry_raw_adc[0],-1);
+  raw_adc_diff[1]->Draw();
+  raw_adc_diff[1]->SetLineColor(kGreen-2);
+
+  cy->cd(3);
+  rb_fry_adc[0]->Draw();
+  rb_fry_adc[1]->Draw("same");
+  rb_fry_adc[0]->SetLineColor(2);
+
+  cy->cd(4);
+  adc_diff[1]->Add(rb_fry_adc[1],rb_fry_adc[0],-1);
+  adc_diff[1]->Draw();
+  adc_diff[1]->SetLineColor(kGreen-2);
+
+  cy->cd(5);
+  rb_fry[0]->Draw();
+  rb_fry[0]->SetLineColor(2);
+  rb_fry[1]->Draw("same");
+
+  cy->cd(6);
+  pos_diff[1]->Add(rb_fry[1],rb_fry[0],-1);
+  pos_diff[1]->Draw();
+  pos_diff[1]->SetLineColor(kGreen-2);
+
+  
+}

--- a/Macros/mapedit_rasterbcm.pl
+++ b/Macros/mapedit_rasterbcm.pl
@@ -1,0 +1,154 @@
+#!/usr/bin/perl
+
+# Rewrite a Hall C style MAP file so that the Raster and BPM
+# are separate detector types instead of being part of the
+# MISC detector
+#
+# 08.04.2014 (saw) Modify just raster entries for now
+
+use POSIX qw(strftime);
+
+$RASTERID=18;
+$BCMID=19;
+$SWAPRASTERXY=1;
+
+$thedate = strftime( '%b %e, %Y', localtime );
+
+$ifile = $ARGV[0];
+$ofile = $ARGV[1];
+
+open(IFILE,"<$ifile");
+open(OFILE,">$ofile");
+
+print OFILE "! $ofile  Automatically generated $thedate\n";
+print OFILE "! from $ifile by $0\n";
+
+# Insert comments defining the raster and BCM detector IDS
+$ininiddefs=0;
+while(<IFILE>) {
+    chomp;
+    $line = $_;
+    if($line=~/_ID/) {
+	$iniddefs=1;
+    } elsif ($iniddefs) {
+	if(not $line=~/_ID/ and not $line=~/:/) {
+	    print OFILE "! RASTER_ID=$RASTERID       ADC\n";
+	    print OFILE "! BCM_ID=$RASTERID          ADC\n";
+	    print OFILE "$line\n";
+	    last;
+	}
+    }
+    print OFILE "$line\n";
+}
+
+# Copy the rest of the file, looking for the specific channels to
+# edit
+$detector=0;
+while(<IFILE>) {
+    chomp;
+    $line = $_;
+
+    if($line=~/^\s*DETECTOR=\s*(\d*)/i) {
+	$detector=$1;
+	print "$detector\n";
+	print OFILE "$line\n";
+    } elsif ($line=~/^\s*(\d*)\s*,\s*(\d*)\s*,\s*(\d*),\s*(\d*)\s*(.*)/) {
+	$comment = $5;
+	$channel = $1;
+	$plane = $2;
+	$element = $3;
+	$signal = $4;
+	if($comment=~"Fast Raster") {
+	    $signal = -1;
+	    if($comment=~"X-sync") {
+		$signal = 0;
+	    } elsif ($comment=~"X-signal") {
+		$signal = 1;
+	    } elsif ($comment=~"Y-sync") {
+		$signal = 2;
+	    } elsif ($comment=~"Y-signal") {
+		$signal = 3;
+	    }
+	    if($signal>=0) {
+		if ($SWAPRASTERXY) {
+		    $signal = ($signal+2) % 4;
+		}
+		print OFILE "detector=$RASTERID ! RASTER\n";
+		print OFILE "!$line\n";
+		print OFILE "$channel, 1, 1, $signal $comment\n";
+		print OFILE "detector=$detector ! RASTER\n";
+	    } else {
+	    print OFILE "$line\n";
+	    }
+	} else {
+	    print OFILE "$line\n";
+	}
+    } else {
+	print OFILE "$line\n";
+    }
+}
+exit;
+
+%crates=();
+
+$crate = 0;
+$nsubadd = 0;
+$bsub = 0;
+$modtype = 0;
+$slot = 0;
+while(<>) {
+    $line=chomp;
+    if($line=/^\s*ROC=\s*(\d*)/i) {
+	$i++;
+	$crate = $1;
+	if(not $crates{$crate}) {
+	    $slotlist={};
+	    $crates{$crate} = $slotlist;
+	}
+	$modtype = 0;
+	$slot = 0;
+    } elsif ($line=/^\s*nsubadd=\s*(\d*)/i) {
+	$nsubadd = $1;
+	$modtype = 0;
+    } elsif ($line=/^\s*bsub=\s*(\d*)/i) {
+	$bsub = $1;
+	$modtype = 0;
+    } elsif ($line=/^\s*slot=\s*(\d*)/i) {
+	$slot = $1;
+	$modtype = 0;
+    } elsif ($line=/^\s*(\d*)\s*,\s*(\d*)\s*,\s*(\d*)/) {
+	if($modtype == 0) {	# Slot not yet registered
+	    if($nsubadd == 96) {
+		$modtype = 1877;
+	    } elsif($nsubadd == 64) {
+		if($bsub == 16) {
+		    $modtype = 1875;
+		} elsif($bsub == 17) {
+		    $modtype = 1881;
+		}
+	    }
+	    if($modtype == 0) {
+		print "Unknown module Crate $crate, Slot $slot\n";
+	    }
+	    $crates{$crate}{$slot} = $modtype;
+	    # print "$crate $slot $modtype\n";
+	}
+    }
+}
+print "# Hall C Crate map\n";
+foreach $crate (sort {$a <=> $b} keys %crates) {
+    print "==== Crate $crate type fastbus\n";
+    print "# slot  model   clear   header  mask    nchan   ndata\n";
+    foreach $slot (sort {$a <=> $b} keys %{ $crates{$crate}}) {
+	$modtype = $crates{$crate}{$slot};
+	if($modtype == 1877) {
+	    $ndata = 256;
+	} else {
+	    $ndata = 64;
+	}
+	printf " %2d     %d    1       0x0     0x0    %3d      %d\n"
+	    ,$slot,$modtype,$nsubadd, $ndata;
+    }
+}
+
+


### PR DESCRIPTION
Fixed the wrong variable definitions for raster signals. raster signals not be arrays!

Adding the Macros/mapedit_rasterbcm.pl for converting ENGINE type channel map files to HCAN type map files. I initially added this script to hcana/examples. But I realize the better location for it is the hcana_replay directory.

Adding  Macros/comp_beam_engine_hcana.C to generate plots for raster signal comparison. For each signal, the script will generate an overlayed histogram and a difference histogram.
