### PR TITLE
Moved cut definitions from the output_replay_both.def 

### DIFF
--- a/cuts_replay_both.def
+++ b/cuts_replay_both.def
@@ -19,6 +19,8 @@ Decode_master     all_event
 
 Block: CoarseTracking
 CoarseTracking_master !Pedestal_event
+hfoundtrack   H.dc.ntrack>0&&hmscoin_event
+hfound1track   H.dc.ntrack==1&&hmscoin_event
 
 Block: CoarseReconstruct
 RawCoarseReconstruct !Pedestal_event

--- a/output_replay_both.def
+++ b/output_replay_both.def
@@ -11,13 +11,14 @@ block S.tr.*
 block S.dc.*
 block S.hod.*
 block S.cal.*
+block S.cher.*
 block g.evnum
 block RB.*
 
 # cuts
-cut hfoundtrack   H.dc.ntrack>0
-cut hfound1track   H.dc.ntrack==1
-cut hmscoin_event     g.evtyp==1||g.evtyp==3
+#cut hfoundtrack   H.dc.ntrack>0
+#cut hfound1track   H.dc.ntrack==1
+#cut hmscoin_event     g.evtyp==1||g.evtyp==3
 # TDC spectra
 TH1F hfptime1x ' HMS s1x fptime' H.hod.1x.fptime 80 0. 80. hfoundtrack
 TH1F hfptime1y ' HMS s1y fptime' H.hod.1y.fptime 80 0. 80. hfoundtrack 

--- a/report.template
+++ b/report.template
@@ -1,0 +1,47 @@
+
+           This is a report template file.
+
+It can be used to create simple run summary/statistics output files.
+
+To produce a report, put in your analysis steering script, the line 
+
+   analyzer->PrintReport(templatefilename, reportfilename); 
+
+where analyzer is your analyzer object.
+
+The template file is copied to the output file, except that anything
+inside of the braces gets evaluated.  If the braces contain a string variable,
+the value of variable replaces the braced name.  Otherwise what is
+in the braces is evaluated as an expression.  Currently the expression can be
+composed of Hall C style parameter variables, cut results (not really too usefull)
+and cut statistics.  (Number of times called and number of times passed.)
+
+For example, {100*Pedestal_event.npassed/Pedestal_event.ncalled:%.2f}% is the percentage of events that were pedestal events.
+Number of pedestal events:  {Pedestal_event.npassed}  {Pedestal_event.ncalled}
+Number of HMS events:  {HMS_event.npassed}  {HMS_event.ncalled}
+Number of scalar   events:  {scalar_event.npassed}  {scalar_event.ncalled}
+Number of hfoundtrack  events:  {hfoundtrack.npassed}  
+ hfoundtrack/Number of HMS events: {hfoundtrack.npassed/HMS_event.npassed:%.5f}
+
+Horizontal drift chamber z positions:
+Chamber 1: {hdc_zpos[0]:%6.2f} {hdc_zpos[1]:%6.2f} {hdc_zpos[2]:%6.2f} {hdc_zpos[3]:%6.2f} {hdc_zpos[4]:%6.2f} {hdc_zpos[5]:%6.2f} 
+Chamber 2: {hdc_zpos[6]:%6.2f} {hdc_zpos[7]:%6.2f} {hdc_zpos[8]:%6.2f} {hdc_zpos[9]:%6.2f} {hdc_zpos[10]:%6.2f} {hdc_zpos[11]:%6.2f} 
+
+The expression result can be formatted by putting a ":" followed by
+a c-style format after the expression.
+
+The HMS reconstruction coefficient file name is {h_recon_coeff_filename}
+The names of the HMS drift chamber planes are: {hdc_plane_names}
+
+DC Events: {hdc_tot_events}
+Hit in chamber: {hdc_cham_hits[0]/hdc_tot_events:%.3f} {hdc_cham_hits[1]/hdc_tot_events:%.3f}
+Hit in plane: {hdc_events[0]/hdc_tot_events:%.3f} {hdc_events[1]/hdc_tot_events:%.3f} {hdc_events[2]/hdc_tot_events:%.3f} {hdc_events[3]/hdc_tot_events:%.3f} {hdc_events[4]/hdc_tot_events:%.3f} {hdc_events[5]/hdc_tot_events:%.3f} {hdc_events[6]/hdc_tot_events:%.3f} {hdc_events[7]/hdc_tot_events:%.3f} {hdc_events[8]/hdc_tot_events:%.3f} {hdc_events[9]/hdc_tot_events:%.3f} {hdc_events[10]/hdc_tot_events:%.3f} {hdc_events[11]/hdc_tot_events:%.3f}
+
+Run #{gen_run_number}
+first event = {gen_run_starting_event:%7d}
+last event  = {gen_event_id_number:%7d}
+
+Later, such things as hardware scalers will be added to the set of variables
+that can be used in expressions.
+
+


### PR DESCRIPTION
Moved cut definitions from the output_replay_both.def to cuts_replay_bot.h.def
so that they cuts can be accessed for the report template